### PR TITLE
Remove references to ::shadow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/braver/fonts",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.1.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   },
   "dependencies": {},
   "keywords": [

--- a/styles/functions.less
+++ b/styles/functions.less
@@ -60,20 +60,17 @@
   //force loading all styles
   fonts-fixer,
   //set the base editor font
-  atom-text-editor,
-  atom-text-editor::shadow {
+  atom-text-editor {
     font-family: @fontFamily;
   }
   //force the mini editor in settings for ui themes that change that (i.e. Isotope)
-  .settings-view atom-text-editor.mini,
-  .settings-view atom-text-editor.mini::shadow {
+  .settings-view atom-text-editor.mini {
     font-family: @fontFamily !important;
   }
 }
 
 .no-smoothing() {
-  atom-text-editor:not(.mini),
-  atom-text-editor:not(.mini)::shadow {
+  atom-text-editor:not(.mini) {
     font-smooth: never;
     -webkit-font-smoothing : none;
   }


### PR DESCRIPTION
Shouldn't be merged until you're ready to create a release for Atom v1.13.

Fixes #42 