### PR TITLE
Fix Average Mono bold-italic

### DIFF
--- a/styles/fonts.less
+++ b/styles/fonts.less
@@ -10,8 +10,8 @@
 .font ( 'Anonymous Pro', normal, italic, 'anonymous-pro/anonymous-pro-italic.ttf' );
 .font ( 'Anonymous Pro', normal, normal, 'anonymous-pro/anonymous-pro.ttf' );
 .font ( 'Aurulent Sans Mono', normal, normal, 'aurulent/aurulent.otf' );
+.font ( 'Average Mono', bold, italic, 'average/average-bold-italic.otf' );
 .font ( 'Average Mono', bold, normal, 'average/average-bold.otf' );
-.font ( 'Average Mono', normal, italic, 'average/average-bold-italic.otf' );
 .font ( 'Average Mono', normal, italic, 'average/average-italic.otf' );
 .font ( 'Average Mono', normal, normal, 'average/average.otf' );
 .font ( 'BPmono', bold, normal, 'bpmono/bpmono-bold.woff' );


### PR DESCRIPTION
Noticed that Average Mono bold-italic font face is listed as `normal italic` in CSS. I assume this was a copy-paste error.