### PR TITLE
Fix plex mono font

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "Office Code Pro Medium",
         "Oxygen Mono",
         "Overpass Mono",
-        "Plex",
+        "Plex Mono",
         "PT Mono",
         "Profont",
         "Proggy Clean",

--- a/styles/fonts.less
+++ b/styles/fonts.less
@@ -181,10 +181,10 @@
 .font ( 'Overpass Mono', normal, normal, 'overpass/overpass.woff' );
 .font ( 'Overpass Mono', bold, normal, 'overpass/overpass-bold.woff' );
 .font ( 'Oxygen Mono', normal, normal, 'oxygen/oxygen.otf' );
-.font ( 'Plex', bold, italic, 'plex/plex-bold-italic.woff' );
-.font ( 'Plex', bold, normal, 'plex/plex-bold.woff' );
-.font ( 'Plex', normal, italic, 'plex/plex-italic.woff' );
-.font ( 'Plex', normal, normal, 'plex/plex.woff' );
+.font ( 'Plex Mono', bold, italic, 'plex-mono/plex-mono-semibold-italic.woff' );
+.font ( 'Plex Mono', bold, normal, 'plex-mono/plex-mono-semibold.woff' );
+.font ( 'Plex Mono', normal, italic, 'plex-mono/plex-mono-italic.woff' );
+.font ( 'Plex Mono', normal, normal, 'plex-mono/plex-mono.woff' );
 .font ( 'PT Mono', normal, normal, 'pt/pt.ttf' );
 .font ( 'Profont', normal, normal, 'profont/profont.ttf' );
 .font ( 'Proggy Clean', normal, normal, 'proggy-clean/proggy-clean.ttf' );


### PR DESCRIPTION
Found this while playing around with the generator. `plex` font is located in `resources/plex-mono/plex-mono.woff`, but `fonts.less` referred to it via `resources/plex/plex.woff`.

Not sure how this happened, but anyway, here's the fix.